### PR TITLE
Changed pu_signature_image column type to LONGTEXT

### DIFF
--- a/Database/SQL_Scripts/01_create_tables.sql
+++ b/Database/SQL_Scripts/01_create_tables.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS Task (
     pu_planned_time     TIMESTAMP       NOT NULL,     
     pu_address          VARCHAR(255)    NOT NULL,   
 
-    pu_signature_image  TEXT,
+    pu_signature_image  LONGTEXT,
     pu_signed_at        TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP(),
     
     PRIMARY KEY (uuid),


### PR DESCRIPTION
LONGTEXT is used instead of MEDIUMTEXT because MEDIUMTEXT max capacity is 16MB, we don't know if the signature could get over that or not so LONGTEXT is better in this case